### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @JasonLiu1229 @OrfeoTerkuci


### PR DESCRIPTION
This PR adds a CODEOWNERS file, which contains both me and @JasonLiu1229

Whenever a PR is opened that modifies a piece of the project that the code owner owns (right not that includes the whole repository), they are assigned as reviewer.

For more information: [Github CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners)